### PR TITLE
use https for git clone

### DIFF
--- a/_root/200-howto.md
+++ b/_root/200-howto.md
@@ -19,7 +19,7 @@ by building from [sources](https://github.com/glk/pefs).
 ~~~~~~~~
 
 ~~~~~~~~
-# git clone git://github.com/glk/pefs.git pefs
+# git clone https://github.com/glk/pefs.git pefs
 # cd pefs
 # make obj all
 # make install


### PR DESCRIPTION
git is an insecure protocol as it is plain text with no authentication allowing a MitM attacker to change the checkout to insert backdoors, etc.  Use https instead.